### PR TITLE
set collection properties

### DIFF
--- a/arlas/cli/cli.py
+++ b/arlas/cli/cli.py
@@ -1,3 +1,4 @@
+import requests
 import typer
 import os
 import sys
@@ -62,6 +63,18 @@ def init(
 
 
 def main():
+    try:
+        json = requests.get('https://pypi.org/pypi/arlas.cli/json').json()
+        if json:
+            version = json.get("info", {}).get("version", None)
+            if version:
+                if not version == arlas_cli_version:
+                    print("WARNING: You are not using the latest version of arlas_cli! Please update with:", file=sys.stderr)
+                    print("pip3.10 install arlas_cli==" + version, file=sys.stderr)
+            else:
+                print("WARNING: Can not identify arlas.cli version.", file=sys.stderr)
+    except Exception:
+        print("WARNING: Can not contact pypi.org to identify if this arlas_cli is the latest version.", file=sys.stderr)
     app.add_typer(collections, name="collections")
     app.add_typer(indices, name="indices")
     app.add_typer(persist, name="persist")

--- a/arlas/cli/collections.py
+++ b/arlas/cli/collections.py
@@ -52,6 +52,54 @@ def describe(
     print(tab)
 
 
+@collections.command(help="Set collection visibility to public")
+def public(
+    collection: str = typer.Argument(help="Collection's name")
+):
+    config = variables["arlas"]
+    ispublic = Service.set_collection_visibility(config, collection, public=True)
+    print("{} is {}".format(collection, "public" if ispublic else "private"))
+
+
+@collections.command(help="Set collection visibility to private")
+def private(
+    collection: str = typer.Argument(help="Collection's name")
+):
+    config = variables["arlas"]
+    ispublic = Service.set_collection_visibility(config, collection, public=False)
+    print("{} is {}".format(collection, "public" if ispublic else "private"))
+
+
+@collections.command(help="Share the collection with the organisation")
+def share(
+    collection: str = typer.Argument(help="Collection's name"),
+    organisation: str = typer.Argument(help="Organisation's name")
+):
+    config = variables["arlas"]
+    shared = Service.share_with(config, collection, organisation)
+    print("{} is shared with {}".format(collection, ", ".join(shared)))
+
+
+@collections.command(help="Share the collection with the organisation")
+def unshare(
+    collection: str = typer.Argument(help="Collection's name"),
+    organisation: str = typer.Argument(help="Organisation's name")
+):
+    config = variables["arlas"]
+    shared = Service.unshare_with(config, collection, organisation)
+    print("{} is shared with {}".format(collection, ", ".join(shared)))
+
+
+@collections.command(help="Set the collection display name", name="name")
+def set_display_name(
+    collection: str = typer.Argument(help="Collection's name"),
+    name: str = typer.Argument(help="The display name")
+):
+    config = variables["arlas"]
+    name = Service.set_collection_display_name(config, collection, name)
+    print("{} display name is {}".format(collection, name))
+
+
 @collections.command(help="Display a sample of a collection")
 def sample(
     collection: str = typer.Argument(help="Collection's name"),

--- a/arlas/cli/service.py
+++ b/arlas/cli/service.py
@@ -150,19 +150,13 @@ class Service:
     def set_collection_visibility(arlas: str, collection: str, public: bool):
         description = Service.__arlas__(arlas, "/".join(["explore", collection, "_describe"]))
         doc = {
-            "organisations": {
-                "shared": description.get("params", {}).get("organisations", {}).get("shared", []),
-                "public": public
-            }
+            "shared": description.get("params", {}).get("organisations", {}).get("shared", []),
+            "public": public
         }
         return Service.__arlas__(arlas, "/".join(["collections", collection, "organisations"]), patch=json.dumps(doc)).get("params", {}).get("organisations", {}).get("public")
 
     def set_collection_display_name(arlas: str, collection: str, name: str):
-        doc = {
-            "display_names": {
-                "collection": name
-            }
-        }
+        doc = name
         return Service.__arlas__(arlas, "/".join(["collections", collection, "display_names"]), patch=json.dumps(doc)).get("params", {}).get("display_names", {}).get("collection")
 
     def share_with(arlas: str, collection: str, organisation: str):


### PR DESCRIPTION
New options to set collections properties:
- set collection public
- set collection private
- share collection with an organisation
- unshare a collection with an organisation
- set display name of the collection

Note: I had to add the PATCH method to the requests.

New commands on `collections`:
```
  name      Set the collection display name
  private   Set collection visibility to private
  public    Set collection visibility to public
  share     Share the collection with the organisation
  unshare   Share the collection with the organisation
```