### PR TITLE
update to arlas 26.0.2, add set_alias and fix set collection name

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,5 +13,9 @@ jobs:
     - name: Install requirements
       run: |
         pip install -r requirements.txt
+    - name: Start the stack
+      run: scripts/start_stack.sh
     - name: Run tests
       run: scripts/tests.sh
+    - name: Stop the stack
+      run: scripts/stop_stack.sh

--- a/arlas/cli/collections.py
+++ b/arlas/cli/collections.py
@@ -100,6 +100,19 @@ def set_display_name(
     print("{} display name is {}".format(collection, name))
 
 
+@collections.command(help="Set the collection display name", name="set_alias")
+def set_field_display_name(
+    collection: str = typer.Argument(help="Collection's name"),
+    field_path: str = typer.Argument(help="The field path"),
+    display_name: str = typer.Argument(help="The field's display name. If none provided, then the alias is removed if it existed", default=None)
+):
+    config = variables["arlas"]
+    fields = Service.set_collection_field_display_name(config, collection, field_path, display_name)
+    tab = PrettyTable(fields[0], align="l")
+    tab.add_rows(fields[1:])
+    print(tab)
+
+
 @collections.command(help="Display a sample of a collection")
 def sample(
     collection: str = typer.Argument(help="Collection's name"),

--- a/arlas/cli/collections.py
+++ b/arlas/cli/collections.py
@@ -20,9 +20,7 @@ def configuration(config: str = typer.Option(help="Name of the ARLAS configurati
 def list_collections():
     config = variables["arlas"]
     collections = Service.list_collections(config)
-    tab = PrettyTable(collections[0], sortby="name", align="l")
-    tab.add_rows(collections[1:])
-    print(tab)
+    __print_table(collections[0], collections[1:], sortby="name")
 
 
 @collections.command(help="Count the number of hits within a collection (or all collection if not provided)")
@@ -31,9 +29,7 @@ def count(
 ):
     config = variables["arlas"]
     count = Service.count_collection(config, collection)
-    tab = PrettyTable(count[0], sortby="collection name", align="l")
-    tab.add_rows(count[1:])
-    print(tab)
+    __print_table(count[0], count[1:], sortby="collection name")
 
 
 @collections.command(help="Describe a collection")
@@ -42,14 +38,10 @@ def describe(
 ):
     config = variables["arlas"]
     fields = Service.describe_collection(config, collection)
-    tab = PrettyTable(fields[0], sortby="field name", align="l")
-    tab.add_rows(fields[1:])
-    print(tab)
+    __print_table(fields[0], fields[1:], sortby="field name")
 
     fields = Service.metadata_collection(config, collection)
-    tab = PrettyTable(fields[0], align="l")
-    tab.add_rows(fields[1:])
-    print(tab)
+    __print_table(fields[0], fields[1:], sortby=None)
 
 
 @collections.command(help="Set collection visibility to public")
@@ -108,9 +100,7 @@ def set_field_display_name(
 ):
     config = variables["arlas"]
     fields = Service.set_collection_field_display_name(config, collection, field_path, display_name)
-    tab = PrettyTable(fields[0], align="l")
-    tab.add_rows(fields[1:])
-    print(tab)
+    __print_table(fields[0], fields[1:], sortby=None)
 
 
 @collections.command(help="Display a sample of a collection")
@@ -179,3 +169,10 @@ def create(
         geometry_path=geometry_path,
         date_path=date_path)
     print("Collection {} created on {}".format(collection, config))
+
+
+def __print_table(field_names: list[str], rows, sortby: str = None):
+    tab = PrettyTable(field_names, sortby=sortby, align="l")
+    tab.add_rows(rows)
+    print(tab)
+

--- a/docker/dc-test.yaml
+++ b/docker/dc-test.yaml
@@ -88,7 +88,7 @@ services:
     logging:
       driver: ${DOCKER_LOGGING_DRIVER:-json-file}
     healthcheck:
-          test: ["CMD","java","HttpHealthcheck.java","http://localhost:9997/arlas_persistence_server/swagger.json"]
+          test: ["CMD","java","HttpHealthcheck.java","http://localhost:9997/arlas_persistence_server/openapi.json"]
           interval: 5s
           timeout: 10s
           retries: 3

--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -6,7 +6,6 @@
                                                                       
  Usage: python -m arlas.cli.cli collections [OPTIONS] COMMAND         
  [ARGS]...                                                            
-                                                                      
 ╭─ Options ──────────────────────────────────────────────────────────╮
 │ *  --config        TEXT  Name of the ARLAS configuration to use    │
 │                          from your configuration file              │
@@ -16,18 +15,19 @@
 │    --help                Show this message and exit.               │
 ╰────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ─────────────────────────────────────────────────────────╮
-│ count     Count the number of hits within a collection (or all     │
-│           collection if not provided)                              │
-│ create    Create a collection                                      │
-│ delete    Delete a collection                                      │
-│ describe  Describe a collection                                    │
-│ list      List collections                                         │
-│ name      Set the collection display name                          │
-│ private   Set collection visibility to private                     │
-│ public    Set collection visibility to public                      │
-│ sample    Display a sample of a collection                         │
-│ share     Share the collection with the organisation               │
-│ unshare   Share the collection with the organisation               │
+│ count      Count the number of hits within a collection (or all    │
+│            collection if not provided)                             │
+│ create     Create a collection                                     │
+│ delete     Delete a collection                                     │
+│ describe   Describe a collection                                   │
+│ list       List collections                                        │
+│ name       Set the collection display name                         │
+│ private    Set collection visibility to private                    │
+│ public     Set collection visibility to public                     │
+│ sample     Display a sample of a collection                        │
+│ set_alias  Set the collection display name                         │
+│ share      Share the collection with the organisation              │
+│ unshare    Share the collection with the organisation              │
 ╰────────────────────────────────────────────────────────────────────╯
 
 ```

--- a/docs/docs/started.md
+++ b/docs/docs/started.md
@@ -4,6 +4,8 @@ Install `arlas_cli` ([prerequisite](install.md#Prerequisite))
 > pip install arlas_cli
 ```
 
+The version of `arlas_cli` is `xxx.yyy` where `xxx` is ARLAS Stack main version and `yyy` is the increment of arlas_cli version.
+
 !!! warning "Prerequisite"
     For running the various examples bellow, ARLAS and elasticsearch must be running on the local machine: clone the [ARLAS Stack Exploration](https://github.com/gisaia/ARLAS-Exploration-stack) project and run `./start.sh` .
 

--- a/scripts/stack.env
+++ b/scripts/stack.env
@@ -1,9 +1,9 @@
 ################################################
 # Docker images versions
 ################################################
-ARLAS_SERVER_VERSION=gisaia/arlas-server:24.1.0
+ARLAS_SERVER_VERSION=gisaia/arlas-server:26.0.2
 ELASTIC_VERSION=docker.elastic.co/elasticsearch/elasticsearch:8.11.1
-ARLAS_PERSISTENCE_SERVER_VERSION=gisaia/arlas-persistence-server:24.0.5
+ARLAS_PERSISTENCE_SERVER_VERSION=gisaia/arlas-persistence-server:26.0.0
 
 ################################################
 # Credentials

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
 
-./scripts/start_stack.sh
 if test -f "/tmp/arlas_cli.yaml"; then
     rm /tmp/arlas_cli.yaml
 fi
@@ -115,6 +114,24 @@ if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml collections --c
     echo "OK: collection found"
 else
     echo "ERROR: collection not found"
+    exit 1
+fi
+
+# ----------------------------------------------------------
+echo "TEST set field alias"
+if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml collections --config tests set_alias courses track.visibility.proportion Proportion | grep Proportion ; then
+    echo "OK: Alias found"
+else
+    echo "ERROR: alias not found"
+    exit 1
+fi
+
+# ----------------------------------------------------------
+echo "TEST set collection name"
+if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml collections --config tests name courses thecourses | grep thecourses ; then
+    echo "OK: Collection name found"
+else
+    echo "ERROR: Collection name not found"
     exit 1
 fi
 
@@ -260,5 +277,3 @@ else
     echo "ERROR: groups not found"
     exit 1
 fi
-
-./scripts/stop_stack.sh


### PR DESCRIPTION
- add `set_alias` to set a display name for a field path, add tests
- fix `name` operation to set the display name of a collection, add tests
- move to arlas server `26.0.2`
- update documentation

Side changes: 
- move out the start / stop from the `tests.sh`
- update CI with that change
