### PR TITLE
copy an index or migrate between clusters

### DIFF
--- a/arlas/cli/index.py
+++ b/arlas/cli/index.py
@@ -112,6 +112,7 @@ def data(
         Service.index_hits(config, index=index, file_path=file, bulk_size=bulk, count=count)
         i = i + 1
 
+
 @indices.command(help="Generate the mapping based on the data")
 def mapping(
     file: str = typer.Argument(help="Path to the file conaining the data. Format: NDJSON"),

--- a/arlas/cli/index.py
+++ b/arlas/cli/index.py
@@ -37,6 +37,31 @@ def describe(
     print(tab)
 
 
+@indices.command(help="Clone an index and set its name")
+def clone(
+    index: str = typer.Argument(help="index's name"),
+    name: str = typer.Argument(help="Cloned index's name")
+):
+    config = variables["arlas"]
+    indices = Service.clone_index(config, index, name)
+    tab = PrettyTable(indices[0], sortby="name", align="l")
+    tab.add_rows(indices[1:])
+    print(tab)
+
+
+@indices.command(help="Migrate an index on another arlas configuration, and set the target index name")
+def migrate(
+    index: str = typer.Argument(help="index's name"),
+    arlas_target: str = typer.Argument(help="ARLAS Configuration name"),
+    name: str = typer.Argument(help="Migrated index's name")
+):
+    config = variables["arlas"]
+    indices = Service.migrate_index(config, index, arlas_target, name)
+    tab = PrettyTable(indices[0], sortby="name", align="l")
+    tab.add_rows(indices[1:])
+    print(tab)
+
+
 @indices.command(help="Display a sample of an index")
 def sample(
     index: str = typer.Argument(help="index's name"),

--- a/arlas/cli/index.py
+++ b/arlas/cli/index.py
@@ -39,8 +39,8 @@ def describe(
 
 @indices.command(help="Clone an index and set its name")
 def clone(
-    index: str = typer.Argument(help="index's name"),
-    name: str = typer.Argument(help="Cloned index's name")
+    index: str = typer.Argument(help="Source index name"),
+    name: str = typer.Argument(help="Target cloned index name")
 ):
     config = variables["arlas"]
     indices = Service.clone_index(config, index, name)
@@ -51,9 +51,9 @@ def clone(
 
 @indices.command(help="Migrate an index on another arlas configuration, and set the target index name")
 def migrate(
-    index: str = typer.Argument(help="index's name"),
-    arlas_target: str = typer.Argument(help="ARLAS Configuration name"),
-    name: str = typer.Argument(help="Migrated index's name")
+    index: str = typer.Argument(help="Source index name"),
+    arlas_target: str = typer.Argument(help="Target ARLAS Configuration name"),
+    name: str = typer.Argument(help="Target migrated index name")
 ):
     config = variables["arlas"]
     indices = Service.migrate_index(config, index, arlas_target, name)

--- a/arlas/cli/service.py
+++ b/arlas/cli/service.py
@@ -135,11 +135,11 @@ class Service:
             ])
         return table
 
-    def list_indices(arlas: str, keeponly: str = None) -> list[list[str]]:
+    def list_indices(arlas: str, keep_only: str = None) -> list[list[str]]:
         data = json.loads(Service.__es__(arlas, "_cat/indices?format=json"))
         table = [["name", "status", "count", "size"]]
         for index in data:
-            if keeponly is None or keeponly == index.get("index"):
+            if keep_only is None or keep_only == index.get("index"):
                 table.append([
                     index.get("index"),
                     index.get("status"),
@@ -232,7 +232,7 @@ class Service:
         Service.__es__(arlas, "/".join([index, "_block", "write"]), put="")
         Service.__es__(arlas, "/".join([index, "_clone", name]), put="")
         Service.__es__(arlas, "/".join([index, "_settings"]), put='{"index.blocks.write": false}')
-        return Service.list_indices(arlas, keeponly=name)
+        return Service.list_indices(arlas, keep_only=name)
     
     def migrate_index(arlas: str, index: str, target_arlas: str, target_name: str) -> list[list[str]]:
         source = Configuration.settings.arlas.get(arlas)
@@ -255,7 +255,7 @@ class Service:
         Service.__es__(target_arlas, "/".join([target_name]), put=mapping)
         print("3/3: copy data ...")
         print(Service.__es__(target_arlas, "/".join(["_reindex"]), post=json.dumps(migration)))
-        return Service.list_indices(target_arlas, keeponly=target_name)
+        return Service.list_indices(target_arlas, keep_only=target_name)
     
     def sample_collection(arlas: str, collection: str, pretty: bool, size: int) -> dict:
         sample = Service.__arlas__(arlas, "/".join(["explore", collection, "_search"]) + "?size={}".format(size))

--- a/arlas/cli/service.py
+++ b/arlas/cli/service.py
@@ -135,7 +135,7 @@ class Service:
             ])
         return table
 
-    def list_indices(arlas: str, keeponly: None) -> list[list[str]]:
+    def list_indices(arlas: str, keeponly: str = None) -> list[list[str]]:
         data = json.loads(Service.__es__(arlas, "_cat/indices?format=json"))
         table = [["name", "status", "count", "size"]]
         for index in data:

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -96,6 +96,15 @@ else
     exit 1
 fi
 
+# ----------------------------------------------------------
+echo "TEST clone index"
+if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml indices --config tests clone courses courses2 | grep courses | grep " 200   "; then
+    echo "OK: hundred hits found"
+else
+    echo "ERROR: hits not found"
+    exit 1
+fi
+
 
 # ----------------------------------------------------------
 echo "TEST add collection"

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -98,10 +98,11 @@ fi
 
 # ----------------------------------------------------------
 echo "TEST clone index"
-if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml indices --config tests clone courses courses2 | grep courses2 | grep " 200   "; then
-    echo "OK: hundred hits found"
+if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml indices --config tests clone courses courses2 | grep courses2 ; then
+    echo "OK: course2 found"
+    yes | python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml indices --config tests delete courses2
 else
-    echo "ERROR: hits not found"
+    echo "ERROR: course2 not found"
     exit 1
 fi
 

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -98,7 +98,7 @@ fi
 
 # ----------------------------------------------------------
 echo "TEST clone index"
-if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml indices --config tests clone courses courses2 | grep courses | grep " 200   "; then
+if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml indices --config tests clone courses courses2 | grep courses2 | grep " 200   "; then
     echo "OK: hundred hits found"
 else
     echo "ERROR: hits not found"


### PR DESCRIPTION
Add two commands on `indices` :
- `clone`: this clones an index on a same ES cluster, with a different index name
- `migrate` this copy the mapping and data from an index on the cluster to another cluster, with a same or different index name

Test added for copy, not clone (don't know for now how to test with current stack).