### PR TITLE
Fix blocked situation when no conf is defined

### DIFF
--- a/arlas/cli/cli.py
+++ b/arlas/cli/cli.py
@@ -31,9 +31,12 @@ def init(
         print(arlas_cli_version)
     if os.path.exists(variables["configuration_file"]):
         Configuration.init(configuration_file=variables["configuration_file"])
-        if Configuration.settings.arlas and len(Configuration.settings.arlas) > 0:
-            # Configuration is ok.
-            ...
+        if "arlas" in dict(Configuration.settings):
+            if len(Configuration.settings.arlas) > 0:
+                # Configuration is ok.
+                ...
+            else:
+                print("Warning : no configuration available")
         else:
             print("Error : no arlas endpoint found in {}.".format(variables["configuration_file"]), file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
Fix #34 

With these modifications, ARLAS cli tolerate the case when no conf is defined.
It allows to create a new one (which was blocked before) 

NB: It fixes the error in arlas exploration stack `scripts/init_arlas_cli_confs.sh` which remove the default local and is stuck with no confs

NB: The `conf list` command still works well and display:
```
Warning : no configuration available
+------+-----+
| name | url |
+------+-----+
+------+-----+

```