### PR TITLE
add command login to arlas_cli confs

### DIFF
--- a/arlas/cli/arlas_cloud.py
+++ b/arlas/cli/arlas_cloud.py
@@ -1,0 +1,4 @@
+ARLAS_SERVER = "https://cloud.arlas.io/arlas/server"
+ARLAS_PERSISTENCE = "https://cloud.arlas.io/arlas/persistence"
+CONTENT_TYPE = "Content-Type:application/json;charset=utf-8"
+AUTH_TOKEN_URL = "https://cloud.arlas.io/arlas/iam/session"

--- a/arlas/cli/collections.py
+++ b/arlas/cli/collections.py
@@ -12,11 +12,8 @@ collections = typer.Typer()
 
 
 @collections.callback()
-def configuration(config: str = typer.Option(help="Name of the ARLAS configuration to use from your configuration file ({}).".format(variables["configuration_file"]))):
-    variables["arlas"] = config
-    if Configuration.settings.arlas.get(config, None) is None:
-        print("Error: arlas configuration {} not found among [{}]".format(config, ", ".join(Configuration.settings.arlas.keys())), file=sys.stderr)
-        exit(1)
+def configuration(config: str = typer.Option(default=None, help="Name of the ARLAS configuration to use from your configuration file ({}).".format(variables["configuration_file"]))):
+    variables["arlas"] = Configuration.solve_config(config)
 
 
 @collections.command(help="List collections", name="list")

--- a/arlas/cli/configurations.py
+++ b/arlas/cli/configurations.py
@@ -76,14 +76,14 @@ def create_configuration(
     print("Configuration {} created.".format(name))
 
 
-@configurations.command(help="Add a configuration for arlas cloud", name="login")
+@configurations.command(help="Add a configuration for ARLAS Cloud", name="login")
 def login(
     auth_login: str = typer.Argument(help="login"),
-    elastic_login: str = typer.Argument(help="elasticsearch login"),
-    elastic: str = typer.Argument(help="elasticsearch url"),
+    elastic_login: str = typer.Argument(help="Elasticsearch login"),
+    elastic: str = typer.Argument(help="Elasticsearch url"),
     auth_org: str = typer.Option(default=None, help="ARLAS IAM Organization, default is your email domain name"),
     allow_delete: bool = typer.Option(default=True, help="Is delete command allowed for this configuration?"),
-    auth_password: str = typer.Option(default=None, help="password"),
+    auth_password: str = typer.Option(default=None, help="ARLAS password"),
     elastic_password: str = typer.Option(default=None, help="elasticsearch password")
 ):
     if not re.match(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', auth_login):

--- a/arlas/cli/configurations.py
+++ b/arlas/cli/configurations.py
@@ -1,9 +1,11 @@
+import re
 import sys
 import typer
 import yaml
 from prettytable import PrettyTable
 from arlas.cli.settings import ARLAS, AuthorizationService, Configuration, Resource
 from arlas.cli.variables import variables
+import arlas.cli.arlas_cloud as arlas_cloud
 
 configurations = typer.Typer()
 
@@ -27,7 +29,7 @@ def create_configuration(
     persistence: str = typer.Option(default=None, help="ARLAS Persistence url"),
     persistence_headers: list[str] = typer.Option([], help="header (name:value)"),
 
-    elastic: str = typer.Option(default=None, help="dictionary of name/es resources"),
+    elastic: str = typer.Option(default=None, help="elasticsearch url"),
     elastic_login: str = typer.Option(default=None, help="elasticsearch login"),
     elastic_password: str = typer.Option(default=None, help="elasticsearch password"),
     elastic_headers: list[str] = typer.Option([], help="header (name:value)"),
@@ -72,6 +74,60 @@ def create_configuration(
     Configuration.save(variables["configuration_file"])
     Configuration.init(variables["configuration_file"])
     print("Configuration {} created.".format(name))
+
+
+@configurations.command(help="Add a configuration for arlas cloud", name="login")
+def login(
+    auth_login: str = typer.Argument(help="login"),
+    elastic_login: str = typer.Argument(help="elasticsearch login"),
+    elastic: str = typer.Argument(help="elasticsearch url"),
+    auth_org: str = typer.Option(default=None, help="ARLAS IAM Organization, default is your email domain name"),
+    allow_delete: bool = typer.Option(default=True, help="Is delete command allowed for this configuration?"),
+    auth_password: str = typer.Option(default=None, help="password"),
+    elastic_password: str = typer.Option(default=None, help="elasticsearch password")
+):
+    if not re.match(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', auth_login):
+        print("Error: login {} is not a valid email".format(auth_login), file=sys.stderr)
+        exit(1)
+
+    name = "cloud.arlas.io." + auth_login.split("@")[0]
+    if Configuration.settings.arlas.get(name):
+        print("Error: a configuration with that name already exists, please remove it first.", file=sys.stderr)
+        exit(1)
+    print("Creating configuration for {} ...".format(name))
+    if not auth_org:
+        auth_org = auth_login.split("@")[1]
+        print("Using {} as your organisation name.".format(auth_org))
+    if not auth_password:
+        auth_password = typer.prompt("Please enter your password for ARLAS Cloud (account {})\n".format(auth_login), hide_input=True, prompt_suffix="Password:")
+    if not elastic_password:
+        elastic_password = typer.prompt("Thank you, now, please enter your password for elasticsearch (account {})\n".format(elastic_login), hide_input=True, prompt_suffix="Password:")
+
+    create_configuration(
+        name=name,
+        server=arlas_cloud.ARLAS_SERVER,
+        headers=[arlas_cloud.CONTENT_TYPE],
+        persistence=arlas_cloud.ARLAS_PERSISTENCE,
+        persistence_headers=[arlas_cloud.CONTENT_TYPE],
+        elastic=elastic,
+        elastic_login=elastic_login,
+        elastic_password=elastic_password,
+        elastic_headers=[arlas_cloud.CONTENT_TYPE],
+        allow_delete=allow_delete,
+        auth_token_url=arlas_cloud.AUTH_TOKEN_URL,
+        auth_headers=[arlas_cloud.CONTENT_TYPE],
+        auth_org=auth_org,
+        auth_login=auth_login,
+        auth_password=auth_password,
+        auth_arlas_iam=True,
+        auth_client_id=None,
+        auth_client_secret=None,
+        auth_grant_type=None,
+    )
+    Configuration.settings.default = name
+    Configuration.save(variables["configuration_file"])
+    Configuration.init(variables["configuration_file"])
+    print("{} is now your default configuration.".format(name))
 
 
 @configurations.command(help="Delete a configuration", name="delete")

--- a/arlas/cli/iam.py
+++ b/arlas/cli/iam.py
@@ -1,5 +1,4 @@
 
-import sys
 import typer
 
 from arlas.cli.settings import Configuration
@@ -9,8 +8,5 @@ iam = typer.Typer()
 
 
 @iam.callback()
-def configuration(config: str = typer.Option(help="Name of the ARLAS configuration to use from your configuration file ({}).".format(variables["configuration_file"]))):
-    variables["arlas"] = config
-    if Configuration.settings.arlas.get(config, None) is None:
-        print("Error: arlas configuration {} not found among [{}]".format(config, ", ".join(Configuration.settings.arlas.keys())), file=sys.stderr)
-        exit(1)
+def configuration(config: str = typer.Option(default=None, help="Name of the ARLAS configuration to use from your configuration file ({}).".format(variables["configuration_file"]))):
+    variables["arlas"] = Configuration.solve_config(config)

--- a/arlas/cli/index.py
+++ b/arlas/cli/index.py
@@ -13,11 +13,8 @@ indices = typer.Typer()
 
 
 @indices.callback()
-def configuration(config: str = typer.Option(help="Name of the ARLAS configuration to use from your configuration file ({}).".format(variables["configuration_file"]))):
-    variables["arlas"] = config
-    if Configuration.settings.arlas.get(config, None) is None:
-        print("Error: arlas configuration {} not found among [{}]".format(config, ", ".join(Configuration.settings.arlas.keys())), file=sys.stderr)
-        exit(1)
+def configuration(config: str = typer.Option(default=None, help="Name of the ARLAS configuration to use from your configuration file ({}).".format(variables["configuration_file"]))):
+    variables["arlas"] = Configuration.solve_config(config)
 
 
 @indices.command(help="List indices", name="list")
@@ -161,8 +158,8 @@ def delete(
         print("Error: delete on \"{}\" is not allowed. To allow delete, change your configuration file ({}).".format(config, variables["configuration_file"]), file=sys.stderr)
         exit(1)
 
-    if typer.confirm("You are about to delete the index '{}' on  '{}' configuration.\n".format(index, config),
-                     prompt_suffix="Do you want to continue (del {} on {})?".format(index, config),
+    if typer.confirm("You are about to delete the index '{}' on  '{}' configuration.\n".format(index, config),
+                     prompt_suffix="Do you want to continue (del {} on {})?".format(index, config),
                      default=False, ):
         if config != "local" and config.find("test") < 0:
             if typer.prompt("WARNING: You are not on a test environment. To delete {} on {}, type the name of the configuration ({})".format(index, config, config)) != config:

--- a/arlas/cli/persist.py
+++ b/arlas/cli/persist.py
@@ -1,22 +1,18 @@
-import json
-import typer
-import os
 import sys
+
+import typer
 from prettytable import PrettyTable
 
-from arlas.cli.settings import Configuration, Resource
 from arlas.cli.service import Service
+from arlas.cli.settings import Configuration, Resource
 from arlas.cli.variables import variables
 
 persist = typer.Typer()
 
 
 @persist.callback()
-def configuration(config: str = typer.Option(help="Name of the ARLAS configuration to use from your configuration file ({}).".format(variables["configuration_file"]))):
-    variables["arlas"] = config
-    if Configuration.settings.arlas.get(config, None) is None:
-        print("Error: arlas configuration {} not found among [{}]".format(config, ", ".join(Configuration.settings.arlas.keys())), file=sys.stderr)
-        exit(1)
+def configuration(config: str = typer.Option(default=None, help="Name of the ARLAS configuration to use from your configuration file ({}).".format(variables["configuration_file"]))):
+    variables["arlas"] = Configuration.solve_config(config)
 
 
 @persist.command(help="Add an entry, returns its ID", name="add")

--- a/arlas/cli/settings.py
+++ b/arlas/cli/settings.py
@@ -31,10 +31,25 @@ class Settings(BaseModel):
     arlas: dict[str, ARLAS] = Field(default=None, title="dictionary of name/arlas configurations")
     mappings: dict[str, Resource] = Field(default=None, title="dictionary of name/mapping resources")
     models: dict[str, Resource] = Field(default=None, title="dictionary of name/model resources")
+    default: str | None = Field(default=None, title="Name of the default configuration")
 
 
 class Configuration:
     settings: Settings = None
+
+    @staticmethod
+    def solve_config(config: str):
+        if not config:
+            if Configuration.settings.default:
+                print("Using default configuration {}".format(Configuration.settings.default))
+                return Configuration.settings.default
+            else:
+                print("Error: No default configuration, please provide one among [{}]".format(", ".join(Configuration.settings.arlas.keys())), file=sys.stderr)
+                exit(1)
+        if Configuration.settings.arlas.get(config, None) is None:
+            print("Error: arlas configuration {} not found among [{}]".format(config, ", ".join(Configuration.settings.arlas.keys())), file=sys.stderr)
+            exit(1)
+        return config
 
     @staticmethod
     def save(configuration_file: str):

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -9,8 +9,8 @@ if test -f "/tmp/arlas_cli_persist"; then
     rm -rf /tmp/arlas_cli_persist
 fi
 
-python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml --config-file /tmp/arlas_cli.yaml --version
-python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml --config-file /tmp/arlas_cli.yaml confs \
+python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml --version
+python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml confs \
     create tests \
     --server http://localhost:9999/arlas \
     --persistence http://localhost:9997/arlas_persistence_server \
@@ -18,6 +18,16 @@ python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml --config-file /tmp
     --elastic http://localhost:9200 \
     --elastic-headers "Content-Type:application/json" \
     --allow-delete 
+
+# ----------------------------------------------------------
+echo "TEST  configuration added with login"
+python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml confs login support@gisaia.com support@gisaia.com https://some_elastic_search_server  --auth-password toto --elastic-password titi
+if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml confs list | grep "cloud.arlas.io.support" ; then
+    echo "OK: configuration found"
+else
+    echo "ERROR: configuration not found"
+    exit 1
+fi
 
 # ----------------------------------------------------------
 echo "TEST configuration placed in /tmp/"


### PR DESCRIPTION
Add `arlas_cli confs login`. This creates a configuration for cloud.arlas.io, highly simplified compared to `arlas_cli confs create`: just need the login/pwd for arlas and elastic + elastic endpoint.

Also, the created configuration becomes the default configuration: this means that other commands do not need to have the `--config` argument.


```shell
> arlas_cli confs login me@gisaia.com gisaia.com_ingest https://...

Creating configuration for cloud.arlas.io.sylvain.gaudan ...
Using gisaia.com as your organisation name.
Please enter your password for ARLAS Cloud (account me@gisaia.com)
Password: 
Thank you, now, please enter your password for elasticsearch (account gisaia.com_ingest)
Password: 
Configuration cloud.arlas.io.me created.
cloud.arlas.io.me is now your default configuration.
```

Command line help:

```
 Usage: python -m arlas.cli.cli confs login [OPTIONS] AUTH_LOGIN ELASTIC_LOGIN                        
                                            ELASTIC                                                   
                                                                                                      
 Add a configuration for arlas cloud                                                                  
                                                                                                      
╭─ Arguments ────────────────────────────────────────────────────────────────────────────────────────╮
│ *    auth_login         TEXT  login [default: None] [required]                                     │
│ *    elastic_login      TEXT  elasticsearch login [default: None] [required]                       │
│ *    elastic            TEXT  elasticsearch url [default: None] [required]                         │
╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────╮
│ --auth-org                                 TEXT  ARLAS IAM Organization, default is your email     │
│                                                  domain name                                       │
│                                                  [default: None]                                   │
│ --allow-delete        --no-allow-delete          Is delete command allowed for this configuration? │
│                                                  [default: allow-delete]                           │
│ --auth-password                            TEXT  password [default: None]                          │
│ --elastic-password                         TEXT  elasticsearch password [default: None]            │
│ --help                                           Show this message and exit.                       │
╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
