### PR TITLE
Add no-index option to avoid indexing a field

### DIFF
--- a/arlas/cli/index.py
+++ b/arlas/cli/index.py
@@ -119,6 +119,7 @@ def mapping(
     nb_lines: int = typer.Option(default=2, help="Number of line to consider for generating the mapping. Avoid going over 10."),
     field_mapping: list[str] = typer.Option(default=[], help="Override the mapping with the provided field path/type. Example: fragment.location:geo_point. Important: the full field path must be provided."),
     no_fulltext: list[str] = typer.Option(default=[], help="List of keyword or text fields that should not be in the fulltext search. Important: the field name only must be provided."),
+    no_index: list[str] = typer.Option(default=[], help="List of fields that should not be indexed."),
     push_on: str = typer.Option(default=None, help="Push the generated mapping for the provided index name"),
 ):
     config = variables["arlas"]
@@ -138,7 +139,7 @@ def mapping(
             else:
                 print(f"Error: invalid field_mapping \"{fm}\". The format is \"field:type\" like \"fragment.location:geo_point\"", file=sys.stderr)
                 exit(1)
-    mapping = make_mapping(file=file, nb_lines=nb_lines, types=types, no_fulltext=no_fulltext)
+    mapping = make_mapping(file=file, nb_lines=nb_lines, types=types, no_fulltext=no_fulltext, no_index=no_index)
     if push_on and config:
         Service.create_index(
             config,

--- a/docs/docs/indices.md
+++ b/docs/docs/indices.md
@@ -85,15 +85,6 @@ The values of the first lines of the files are used to infer the mapping for eac
 
     Make sure to take enough rows to get all the fields with the option `--nb_lines`
 
-!!! tip
-    The data can be split in different NDJSON files in a folder:
-    ```
-    part-00000-[...].json
-    part-00001-[...].json
-    ...
-    ```
-    In practice, the `file` Argument can be filed with a **pattern** such as `path/to/data.json/part-0000*.json` to reference all the different files.
-
 
 ### Type identification
 
@@ -135,7 +126,7 @@ A **date** is identified as such if
 
 By default, the keywords and text fields are searchable as fulltext to be accessible in the search bar.
 
-!!! note "--no-fulltext "
+!!! note "--no-fulltext"
 
     If searching through a field value is not needed, it can be deactivated.
     That would result in better performances for the fulltext search.
@@ -143,6 +134,17 @@ By default, the keywords and text fields are searchable as fulltext to be access
     Example:
 
     - `--no-fulltext field_keyword`
+
+!!! note "--no-index"
+    If a field doesn't need to be explored in the dashboard, it should be removed before indexing the data.
+
+    Alternatively, you can explicitly exclude the field from being indexed using the `--no-index` option.
+
+    Example:
+
+    - `--no-index unused_field`
+
+    The field will remain in the data but will not be indexed.
 
 ### Created mapping
 
@@ -268,6 +270,15 @@ Example:
    --config {local} \
    data {index_name} {path/to/data.json}
 ```
+
+!!! tip
+    The data can be split in different NDJSON files in a folder:
+    ```
+    part-00000-[...].json
+    part-00001-[...].json
+    ...
+    ```
+    In practice, the `files` argument can be filed with a **pattern** such as `path/to/data.json/part-0000*.json` to reference all the different files.
 
 !!! warning
     If the index already contains data, the data is added to the index.


### PR DESCRIPTION
Add a `--no-index` option in `indices mapping` command to avoid indexing a field

The option name is like to the `--no-fultext` option, coud be named differently (`--ignore-field`, `--no-index-field` ...)?

Also: 
- Rename some variables to make the function more understandable
- Move the "print ---> " to display it for all field (was only displayed for the keyword/text field) and add the infered type