### PR TITLE
Force utf-8 for json encoding

### DIFF
--- a/arlas/cli/model_infering.py
+++ b/arlas/cli/model_infering.py
@@ -171,7 +171,7 @@ def make_mapping(file: str, nb_lines: int = 2, types: dict[str, str] = {}, no_fu
                  no_index: list[str] = []):
     tree = {}
     mapping = {}
-    with open(file) as f:
+    with open(file, mode="r", encoding="utf-8") as f:
         i = 0
         for line in f:
             if i > nb_lines:

--- a/arlas/cli/service.py
+++ b/arlas/cli/service.py
@@ -328,7 +328,7 @@ class Service:
 
     def count_hits(file_path: str) -> int:
         line_number = 0
-        with open(file_path) as f:
+        with open(file_path, mode="r", encoding="utf-8") as f:
             for line in f:
                 line_number = line_number + 1
         return line_number
@@ -388,7 +388,7 @@ class Service:
         line_number = 0
         line_in_bulk = 0
         bulk = []
-        with open(file_path) as f:
+        with open(file_path, mode="r", encoding="utf-8") as f:
             with alive_bar(count) as bar:
                 for line in f:
                     line_number = line_number + 1


### PR DESCRIPTION
Currently, the default json encoding can vary between os (windows), resulting in error in special caracters in ARLAS.

Harmonize it to the standard utf-8 solve this problem. 
Is it ok for you? 