### PR TITLE
set default configuration, check configuration

### DIFF
--- a/arlas/cli/configurations.py
+++ b/arlas/cli/configurations.py
@@ -6,9 +6,40 @@ from prettytable import PrettyTable
 from arlas.cli.settings import ARLAS, AuthorizationService, Configuration, Resource
 from arlas.cli.variables import variables
 import arlas.cli.arlas_cloud as arlas_cloud
+from arlas.cli.service import Service
 
 configurations = typer.Typer()
 
+
+@configurations.command(help="Set default configuration among existing configurations", name="set", epilog=variables["help_epilog"])
+def set_default_configuration(name: str = typer.Argument(help="Name of the configuration to become default")):
+    if not Configuration.settings.arlas.get(name):
+        print("Error: configuration {} not found among {}.".format(name, ",".join(Configuration.settings.arlas.keys())), file=sys.stderr)
+        exit(1)
+    Configuration.settings.default = name
+    Configuration.save(variables["configuration_file"])
+    Configuration.init(variables["configuration_file"])
+    print("Default configuration is now {}".format(name))
+
+
+@configurations.command(help="Display the default configuration", name="default", epilog=variables["help_epilog"])
+def default():
+    print("Default configuration is {}".format(Configuration.settings.default))
+
+
+@configurations.command(help="Check the services of a configuration", name="check", epilog=variables["help_epilog"])
+def test_configuration(name: str = typer.Argument(help="Configuration to be checked")):
+    if not Configuration.settings.arlas.get(name):
+        print("Error: configuration {} not found among {}.".format(name, ",".join(Configuration.settings.arlas.keys())), file=sys.stderr)
+        exit(1)
+    print("ARLAS Server: ... ", end="")
+    print(" {}".format(Service.test_arlas_server(name)))
+    print("ARLAS Persistence: ... ", end="")
+    print(" {}".format(Service.test_arlas_persistence(name)))
+    print("ARLAS IAM: ... ", end="")
+    print(" {}".format(Service.test_arlas_iam(name)))
+    print("Elasticsearch: ... ", end="")
+    print(" {}".format(Service.test_es(name)))
 
 @configurations.command(help="List configurations", name="list", epilog=variables["help_epilog"])
 def list_configurations():

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -40,6 +40,46 @@ else
 fi
 
 # ----------------------------------------------------------
+echo "TEST default configuration set to tests"
+python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml confs set tests
+if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml confs default | grep "Default configuration is tests" ; then
+    echo "OK: default is local"
+else
+    echo "ERROR: local is not default"
+    exit 1
+fi
+
+# ----------------------------------------------------------
+echo "TEST check local configuration"
+if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml confs check tests | grep "ARLAS Server: ...  ok" ; then
+    echo "OK: ARLAS Server is ok"
+else
+    echo "ERROR: ARLAS Server is not ok"
+    exit 1
+fi
+
+if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml confs check tests | grep "ARLAS Persistence: ...  ok" ; then
+    echo "OK: ARLAS Persistence is ok"
+else
+    echo "ERROR: ARLAS Persistence is not ok"
+    exit 1
+fi
+
+if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml confs check tests | grep "ARLAS IAM: ...  not ok " ; then
+    echo "OK: ARLAS IAM is not ok"
+else
+    echo "ERROR: ARLAS IAM not ok not found"
+    exit 1
+fi
+
+if python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml confs check tests | grep "Elasticsearch: ...  ok" ; then
+    echo "OK: Elasticsearch is ok"
+else
+    echo "ERROR: Elasticsearch is not ok"
+    exit 1
+fi
+
+# ----------------------------------------------------------
 echo "TEST add direct mapping on ES"
 python3.10 -m arlas.cli.cli --config-file /tmp/arlas_cli.yaml indices --config tests create direct_mappping_index --mapping tests/mapping.json
 if [ "$? -eq 0" ] ; then


### PR DESCRIPTION
Changes:
- add a command to set default configuration (by default, it is the one created by the command `login`)
- add a command to display the default configuration
- add a command to test a configuration
   - test arlas server
   - test arlas persistence
   - test arlas iam
   - test ES
- implement tests for all the new commands
 