### PR TITLE
Separate doc generation from mkdocs

### DIFF
--- a/mkDocs.sh
+++ b/mkDocs.sh
@@ -1,8 +1,5 @@
 #!/bin/sh -e
 
-# Generate documentation
-python3.10 docs/inject_commands.py docs/docs/*.template
-
 # Copy documentation to target
 rm -rf target/generated-docs
 mkdir -p target/generated-docs

--- a/scripts/generate_doc.sh
+++ b/scripts/generate_doc.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# Generate documentation
+python3.10 docs/inject_commands.py docs/docs/*.template

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -35,7 +35,7 @@ cp /tmp/arlas-cli-release.conf ./configuration.yaml
 git add configuration.yaml
 
 # Generate and publish documentation
-./mkDocs.sh
+./scripts/generate_doc.sh
 pip3.10 install mkdocs-material termynal
 mkdocs gh-deploy -f docs/mkdocs.yml
 


### PR DESCRIPTION
Changes:
- Doc generation is in a new script (used in release)
- Mkdocs is now only used to copy the generated doc at the right place