### PR TITLE
Fix concept links for general documentation

### DIFF
--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -1,6 +1,6 @@
 ## ARLAS Collections
 
-ARLAS collections are built on top of [elasticsearch (ES) index](concepts.md#es-index). They describe the basic data structure for its visualization and elements needed for the data access policy.
+ARLAS collections are built on top of [elasticsearch (ES) index](../../static_docs/concepts.md#es-index). They describe the basic data structure for its visualization and elements needed for the data access policy.
 
 `arlas_cli` provide tools to manage the ARLAS collections with the `collections` command.
 
@@ -15,7 +15,7 @@ ARLAS collections are built on top of [elasticsearch (ES) index](concepts.md#es-
 ╭─ Options ──────────────────────────────────────────────────────────────────╮
 │ --config        TEXT  Name of the ARLAS configuration to use from your     │
 │                       configuration file                                   │
-│                       (/Users/gaudan/.arlas/cli/configuration.yaml).       │
+│                       (/home/willi/.arlas/cli/configuration.yaml).         │
 │                       [default: None]                                      │
 │ --help                Show this message and exit.                          │
 ╰────────────────────────────────────────────────────────────────────────────╯
@@ -85,7 +85,8 @@ The command line options let you specify how the index should be used by the col
 │ --help                                  Show this message and exit.        │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -176,7 +177,8 @@ The collection can be defined by a pretty name. It can be set with `name` subcom
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -219,7 +221,8 @@ The data fields are sometimes not very suitable in ARLAS Exploration dashboards.
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -274,7 +277,8 @@ The `describe` command line provides a description of the collection's structure
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -301,7 +305,8 @@ The `count` command show the total number of elements (data rows) accessible in 
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -329,7 +334,8 @@ The `sample` command show few data rows accessible in a collection.
 │ --help                              Show this message and exit.            │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -362,7 +368,8 @@ To switch a collection from **public** to **private**, use the `private` command
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -390,7 +397,8 @@ To switch a collection from **private** to **public**, use the `public` command:
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -420,7 +428,8 @@ A collection can be shared to other organisation with the `share` command:
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -450,7 +459,8 @@ The access to a collection can be removed with the `unshare` command:
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -478,7 +488,8 @@ The collection can be removed with the `delete` command:
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```

--- a/docs/docs/collections.md.template
+++ b/docs/docs/collections.md.template
@@ -1,6 +1,6 @@
 ## ARLAS Collections
 
-ARLAS collections are built on top of [elasticsearch (ES) index](concepts.md#es-index). They describe the basic data structure for its visualization and elements needed for the data access policy.
+ARLAS collections are built on top of [elasticsearch (ES) index](../../static_docs/concepts.md#es-index). They describe the basic data structure for its visualization and elements needed for the data access policy.
 
 `arlas_cli` provide tools to manage the ARLAS collections with the `collections` command.
 

--- a/docs/docs/confs.md
+++ b/docs/docs/confs.md
@@ -98,7 +98,8 @@ It is possible, with the `arlas_cli confs` command lines, to manage the ARLAS co
 │                                                        and exit.           │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -208,7 +209,8 @@ The `confs longin` allows to create a configuration linked to an ARLAS Cloud acc
 │                                                  exit.                     │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -246,7 +248,8 @@ An existing configuration can be deleted with the `confs delete` sub command:
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -284,7 +287,8 @@ The content of a configuration can be detailed with `confs describe` sub command
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -343,7 +347,8 @@ The list of available configurations can be obtained with `confs list` sub comma
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -379,7 +384,8 @@ The default arlas_cli configuration can be obtained with the `confs default` sub
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -416,7 +422,8 @@ The default arlas_cli configuration can be set with the `confs set` subcommand:
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -452,7 +459,8 @@ You can verify the services accessible through a specific configuration using th
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```

--- a/docs/docs/help.md
+++ b/docs/docs/help.md
@@ -63,7 +63,8 @@ or within a sub command:
 │ --help                          Show this message and exit.                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,10 +1,10 @@
 # About arlas_cli
 
-__ARLAS Command Line Interface__ (`arlas_cli`) is a tool to manage data and [configurations](../static_docs/concepts/#arlas-cli-configuration) in ARLAS.
+__ARLAS Command Line Interface__ (`arlas_cli`) is a tool to manage data and [configurations](../../static_docs/concepts.md#arlas-cli-configuration) in ARLAS.
 
 `arlas_cli` is a Python command line for:
 
-- Managing [Elasticsearch indices](../static_docs/concepts/#es-index):
+- Managing [Elasticsearch indices](../../static_docs/concepts.md#es-index):
     - Generate an index mapping based on [NDJSON data](https://jsonlines.org/){:target="_blank"}
     - Create an index
     - List indices
@@ -12,23 +12,23 @@ __ARLAS Command Line Interface__ (`arlas_cli`) is a tool to manage data and [con
     - Clone an index
     - Migrate an index
     - Delete an index
-- Managing [ARLAS collections](../static_docs/concepts/#arlas-collection)
+- Managing [ARLAS collections](../../static_docs/concepts.md#arlas-collection)
     - Create a collection
     - List collections
     - Describe a collection
     - Delete a collection
-- Managing [arlas_cli configurations](../static_docs/concepts/#arlas-cli-configuration)
+- Managing [arlas_cli configurations](../../static_docs/concepts.md#arlas-cli-configuration)
     - Register an ARLAS/Elasticsearch configuration, with headers and authentication parameters
     - Login to your ARLAS Cloud account
     - List your configurations
     - Delete a configuration
-- Managing [ARLAS Dashboards](../static_docs/concepts/#arlas-dashboards) in persistence
+- Managing [ARLAS Dashboards](../../static_docs/concepts.md#arlas-dashboards) in persistence
     - Create a dashboard from a configuration file
     - List available dashboard
     - Describe a dashboard
     - Delete a dashboard
     - Get the groups accessing dashboards
-- Managing [ARLAS Identity and Access](../static_docs/concepts/#arlas-iam) (ARLAS IAM)
+- Managing [ARLAS Identity and Access](../../static_docs/concepts.md#arlas-iam) (ARLAS IAM)
     - List organisations
     - Add an organisation
     - Within an organisation:

--- a/docs/docs/indices.md
+++ b/docs/docs/indices.md
@@ -2,8 +2,8 @@
 
 ## Elasticsearch index
 
-To be explored in ARLAS dashboards, the data has to be indexed in an [Elasticsearch](concepts.md#elasticsearch) (ES) [index](concepts.md#es-index).
-An index contains the data and a [mapping](concepts.md#es-mapping) to describe how fields have to be interpreted (types).
+To be explored in ARLAS dashboards, the data has to be indexed in an [Elasticsearch](../../static_docs/concepts.md#elasticsearch) (ES) [index](../../static_docs/concepts.md#es-index).
+An index contains the data and a [mapping](../../static_docs/concepts.md#es-mapping) to describe how fields have to be interpreted (types).
 
 `arlas_cli` provide tools to infer mapping from data and manage the ES indices with the `indices` command.
 
@@ -18,7 +18,7 @@ An index contains the data and a [mapping](concepts.md#es-mapping) to describe h
 ╭─ Options ──────────────────────────────────────────────────────────────────╮
 │ --config        TEXT  Name of the ARLAS configuration to use from your     │
 │                       configuration file                                   │
-│                       (/Users/gaudan/.arlas/cli/configuration.yaml).       │
+│                       (/home/willi/.arlas/cli/configuration.yaml).         │
 │                       [default: None]                                      │
 │ --help                Show this message and exit.                          │
 ╰────────────────────────────────────────────────────────────────────────────╯
@@ -72,7 +72,8 @@ An index contains the data and a [mapping](concepts.md#es-mapping) to describe h
 │ --help                          Show this message and exit.                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -92,7 +93,7 @@ The values of the first lines of the files are used to infer the mapping for eac
 
 ### Type identification
 
-The mapping associates to each field of the data a type (see [Elasticsearch type](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html))
+The mapping associates to each field of the data a type (see [Elasticsearch type](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html){:target="_blank"})
 
 A **geometry** is identified as such if
 
@@ -109,7 +110,7 @@ A **date** is identified as such if
 !!! note "--field-mapping"
     If the mapping is wrong, you can overwrite the typing with the `--field-mapping` option.
 
-    It has the structure **field_name:field_type** (see [Elasticsearch type](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html))
+    It has the structure **field_name:field_type** (see [Elasticsearch type](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html){:target="_blank"})
 
     Examples:
 
@@ -120,7 +121,7 @@ A **date** is identified as such if
     - `--field-mapping field_float:double`
     - `--field-mapping field_int:long`
 
-    The date fields have a format that can be specified as **field_name:date-format** with all format accepted by [Elasticsearch date type](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html)
+    The date fields have a format that can be specified as **field_name:date-format** with all format accepted by [Elasticsearch date type](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html){:target="_blank"}
 
     Examples:
 
@@ -211,7 +212,8 @@ The `indices create` sub-function create the index from a mapping json file.
 │    --help                    Show this message and exit.                   │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -264,7 +266,8 @@ The `indices data` sub-function ingest the data in a given index.
 │ --help                 Show this message and exit.                         │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -316,7 +319,8 @@ To list the available ES indices, simply use the `indices list` sub-function. No
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -361,7 +365,8 @@ Once the index is created, the description of the fields it contains (correspond
 │ --help                 Show this message and exit.                         │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -408,7 +413,8 @@ The first rows of the data contained in an index can be displayed with the `indi
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -459,7 +465,8 @@ An ES index can be cloned on the same ES deployment with the `indices clone` sub
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -493,7 +500,8 @@ The target configuration and the name of the new created index are given to the 
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -519,7 +527,8 @@ The ES index can be deleted with `indices delete` sub command to free space on t
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```

--- a/docs/docs/indices.md.template
+++ b/docs/docs/indices.md.template
@@ -2,8 +2,8 @@
 
 ## Elasticsearch index
 
-To be explored in ARLAS dashboards, the data has to be indexed in an [Elasticsearch](concepts.md#elasticsearch) (ES) [index](concepts.md#es-index).
-An index contains the data and a [mapping](concepts.md#es-mapping) to describe how fields have to be interpreted (types).
+To be explored in ARLAS dashboards, the data has to be indexed in an [Elasticsearch](../../static_docs/concepts.md#elasticsearch) (ES) [index](../../static_docs/concepts.md#es-index).
+An index contains the data and a [mapping](../../static_docs/concepts.md#es-mapping) to describe how fields have to be interpreted (types).
 
 `arlas_cli` provide tools to infer mapping from data and manage the ES indices with the `indices` command.
 
@@ -38,7 +38,7 @@ The values of the first lines of the files are used to infer the mapping for eac
 
 ### Type identification
 
-The mapping associates to each field of the data a type (see [Elasticsearch type](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html))
+The mapping associates to each field of the data a type (see [Elasticsearch type](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html){:target="_blank"})
 
 A **geometry** is identified as such if
 
@@ -55,7 +55,7 @@ A **date** is identified as such if
 !!! note "--field-mapping"
     If the mapping is wrong, you can overwrite the typing with the `--field-mapping` option.
 
-    It has the structure **field_name:field_type** (see [Elasticsearch type](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html))
+    It has the structure **field_name:field_type** (see [Elasticsearch type](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html){:target="_blank"})
 
     Examples:
 
@@ -66,7 +66,7 @@ A **date** is identified as such if
     - `--field-mapping field_float:double`
     - `--field-mapping field_int:long`
 
-    The date fields have a format that can be specified as **field_name:date-format** with all format accepted by [Elasticsearch date type](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html)
+    The date fields have a format that can be specified as **field_name:date-format** with all format accepted by [Elasticsearch date type](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html){:target="_blank"}
 
     Examples:
 

--- a/docs/docs/ingest_data.md
+++ b/docs/docs/ingest_data.md
@@ -9,11 +9,11 @@ Ingest Data in ARLAS
 
 ## ARLAS Data structure
 
-To be explored in ARLAS dashboards, the data has to be indexed in an [Elasticsearch](concepts.md#elasticsearch) (ES) [index](concepts.md#es-index).
+To be explored in ARLAS dashboards, the data has to be indexed in an [Elasticsearch](../../static_docs/concepts.md#elasticsearch) (ES) [index](../../static_docs/concepts.md#es-index).
 
-An index contains the data and a model ([mapping](concepts.md#es-mapping)) to describe how fields have to be interpreted (types).
+An index contains the data and a model ([mapping](../../static_docs/concepts.md#es-mapping)) to describe how fields have to be interpreted (types).
 
-ARLAS [collections](concepts.md#arlas-collection) are built on top of indices. 
+ARLAS [collections](../../static_docs/concepts.md#arlas-collection) are built on top of indices. 
 They describe the basic data structure for its visualization and elements needed for the data access policy.
 
 ![Data indices and collections in ARLAS](images/index_collection_schema.png)

--- a/docs/docs/persist.md
+++ b/docs/docs/persist.md
@@ -21,7 +21,7 @@ An entry is an element stored in the persistence.
 ╭─ Options ──────────────────────────────────────────────────────────────────╮
 │ --config        TEXT  Name of the ARLAS configuration to use from your     │
 │                       configuration file                                   │
-│                       (/Users/gaudan/.arlas/cli/configuration.yaml).       │
+│                       (/home/willi/.arlas/cli/configuration.yaml).         │
 │                       [default: None]                                      │
 │ --help                Show this message and exit.                          │
 ╰────────────────────────────────────────────────────────────────────────────╯
@@ -60,7 +60,8 @@ The `persist add` sub-command allows to create an entry from a file.
 │ --help                           Show this message and exit.               │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -102,7 +103,8 @@ The available entries in a zone can be listed with the `persist zone` sub-comman
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -143,7 +145,8 @@ An entry (defined by its unique identifier) can be described with the `persist d
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -192,7 +195,8 @@ The content of an entry can be accessed with the `persist get` sub-command:
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -231,7 +235,8 @@ The groups accessing a zone can be listed with the `persist groups` sub-command:
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```
@@ -270,7 +275,8 @@ An entry defined by its unique identifier can be deleted with the `persist delet
 │ --help          Show this message and exit.                                │
 ╰────────────────────────────────────────────────────────────────────────────╯
                                                                               
- See full arlas_cli documentation at https://gisaia.github.io/arlas_cli/      
+ See full arlas_cli documentation at                                          
+ https://docs.arlas.io/external_docs/arlas_cli/                               
                                                                               
 
 ```

--- a/docs/docs/started.md
+++ b/docs/docs/started.md
@@ -331,6 +331,6 @@ The available dashboards can be list with the following command:
 ```
 
 !!! note
-    The created dashboards can be accessed and managed in [ARLAS Hub](concepts.md#arlas-hub) and edited with [ARLAS Builder](concepts.md#arlas-builder).
+    The created dashboards can be accessed and managed in [ARLAS Hub](../../static_docs/concepts.md#arlas-hub) and edited with [ARLAS Builder](../../static_docs/concepts.md#arlas-builder).
 
     The `arlas_cli` commands to manage dashboards are detailed in [Persistence Documentation](persist.md).


### PR DESCRIPTION
Change:
- Fix concept links with relative paths in general documentation
- Add target to external links to open in new tab
