### PR TITLE
Feat/default conf

### DIFF
--- a/arlas/cli/cli.py
+++ b/arlas/cli/cli.py
@@ -45,12 +45,6 @@ def init(
         os.makedirs(os.path.dirname(variables["configuration_file"]), exist_ok=True)
         Configuration.settings = Settings(
             arlas={
-                "local": ARLAS(
-                    server=Resource(location="http://localhost/arlas", headers={"Content-Type": "application/json"}),
-                    persistence=Resource(location="http://localhost/persist", headers={"Content-Type": "application/json"}),
-                    elastic=Resource(location="http://localhost:9200", headers={"Content-Type": "application/json"}),
-                    allow_delete=True
-                )
             },
             mappings={
             },
@@ -58,7 +52,7 @@ def init(
             }
         )
         Configuration.save(variables["configuration_file"])
-        print("Warning : no configuration file found, we created a default one with a 'local' confs accessing local ARLAS exploration stack ({}).".format(variables["configuration_file"]), file=sys.stderr)
+        print(f"Warning : no configuration file found, we created a default empty one ({variables['configuration_file']}).", file=sys.stderr)
         print("Warning : no configuration available", file=sys.stderr)
 
 

--- a/arlas/cli/configurations.py
+++ b/arlas/cli/configurations.py
@@ -206,10 +206,19 @@ def delete_configuration(
     config: str = typer.Argument(help="Name of the configuration"),
 ):
     check_configuration_exists(name=config)
-    Configuration.settings.arlas.pop(config)
+
+    # Handle default configuration
     if Configuration.settings.default == config:
-        Configuration.settings.default = None
-        print(f"Configuration '{config}' is no longer the default configuration")
+        if typer.confirm(f"You are about to delete the default configuration '{config}'.\n",
+                         prompt_suffix="Do you want to continue?", default=False):
+            Configuration.settings.default = None
+            print(f"No default configuration set any more.")
+        else:
+            print(f"Error: Configuration '{config}' not deleted", file=sys.stderr)
+            exit(1)
+
+    # Delete the configuration
+    Configuration.settings.arlas.pop(config)
     Configuration.save(variables["configuration_file"])
     Configuration.init(variables["configuration_file"])
     print(f"Configuration '{config}' deleted.")

--- a/arlas/cli/configurations.py
+++ b/arlas/cli/configurations.py
@@ -14,12 +14,12 @@ configurations = typer.Typer()
 @configurations.command(help="Set default configuration among existing configurations", name="set", epilog=variables["help_epilog"])
 def set_default_configuration(name: str = typer.Argument(help="Name of the configuration to become default")):
     if not Configuration.settings.arlas.get(name):
-        print(f"Error: configuration {name} not found among {','.join(Configuration.settings.arlas.keys())}.", file=sys.stderr)
+        print(f"Error: configuration '{name}' not found among {','.join(Configuration.settings.arlas.keys())}.", file=sys.stderr)
         exit(1)
     Configuration.settings.default = name
     Configuration.save(variables["configuration_file"])
     Configuration.init(variables["configuration_file"])
-    print(f"Default configuration is now {name}")
+    print(f"Default configuration is now '{name}'")
 
 
 @configurations.command(help="Display the default configuration", name="default", epilog=variables["help_epilog"])
@@ -27,13 +27,13 @@ def default():
     if Configuration.settings.default is None:
         print("No default configuration")
     else:
-        print(f"Default configuration is {Configuration.settings.default}")
+        print(f"Default configuration is '{Configuration.settings.default}'")
 
 
 @configurations.command(help="Check the services of a configuration", name="check", epilog=variables["help_epilog"])
 def test_configuration(name: str = typer.Argument(help="Configuration to be checked")):
     if not Configuration.settings.arlas.get(name):
-        print(f"Error: configuration {name} not found among {','.join(Configuration.settings.arlas.keys())}.",
+        print(f"Error: configuration '{name}' not found among {','.join(Configuration.settings.arlas.keys())}.",
               file=sys.stderr)
         exit(1)
     print("ARLAS Server: ... ", end="")
@@ -115,12 +115,12 @@ def create_configuration(
     if len(Configuration.settings.arlas) == 0:
         # Set the first created configuration as default
         Configuration.settings.default = name
-        print(f"Default configuration is now {name}")
+        print(f"Default configuration is now '{name}'")
 
     Configuration.settings.arlas[name] = conf
     Configuration.save(variables["configuration_file"])
     Configuration.init(variables["configuration_file"])
-    print(f"Configuration {name} created.")
+    print(f"Configuration '{name}' created.")
 
 
 @configurations.command(help="Add a configuration for ARLAS Cloud", name="login", epilog=variables["help_epilog"])
@@ -141,7 +141,7 @@ def login(
     if Configuration.settings.arlas.get(name):
         print("Error: a configuration with that name already exists, please remove it first.", file=sys.stderr)
         exit(1)
-    print(f"Creating configuration for {name} ...")
+    print(f"Creating configuration '{name}' ...")
     if not auth_org:
         auth_org = auth_login.split("@")[1]
         print(f"Using {auth_org} as your organisation name.")
@@ -176,7 +176,7 @@ def login(
     Configuration.settings.default = name
     Configuration.save(variables["configuration_file"])
     Configuration.init(variables["configuration_file"])
-    print(f"{name} is now your default configuration.")
+    print(f"'{name}' is now your default configuration.")
 
 
 @configurations.command(help="Delete a configuration", name="delete", epilog=variables["help_epilog"])
@@ -184,16 +184,16 @@ def delete_configuration(
     config: str = typer.Argument(help="Name of the configuration"),
 ):
     if Configuration.settings.arlas.get(config, None) is None:
-        print(f"Error: arlas configuration {config} not found among [{','.join(Configuration.settings.arlas.keys())}]",
+        print(f"Error: arlas configuration '{config}' not found among [{','.join(Configuration.settings.arlas.keys())}]",
               file=sys.stderr)
         exit(1)
     Configuration.settings.arlas.pop(config)
     if Configuration.settings.default == config:
         Configuration.settings.default = None
-        print(f"Configuration {config} is no longer the default configuration")
+        print(f"Configuration '{config}' is no longer the default configuration")
     Configuration.save(variables["configuration_file"])
     Configuration.init(variables["configuration_file"])
-    print(f"Configuration {config} deleted.")
+    print(f"Configuration '{config}' deleted.")
 
 
 @configurations.command(help="Describe a configuration", name="describe", epilog=variables["help_epilog"])
@@ -201,7 +201,7 @@ def describe_configuration(
     config: str = typer.Argument(help="Name of the configuration"),
 ):
     if Configuration.settings.arlas.get(config, None) is None:
-        print(f"Error: arlas configuration {config} not found among [{','.join(Configuration.settings.arlas.keys())}]",
+        print(f"Error: arlas configuration '{config}' not found among [{','.join(Configuration.settings.arlas.keys())}]",
               file=sys.stderr)
         exit(1)
     print(yaml.dump(Configuration.settings.arlas[config].model_dump()))

--- a/arlas/cli/configurations.py
+++ b/arlas/cli/configurations.py
@@ -178,6 +178,9 @@ def delete_configuration(
         print("Error: arlas configuration {} not found among [{}]".format(config, ", ".join(Configuration.settings.arlas.keys())), file=sys.stderr)
         exit(1)
     Configuration.settings.arlas.pop(config)
+    if Configuration.settings.default == config:
+        Configuration.settings.default = None
+        print(f"Configuration {config} is no longer the default configuration")
     Configuration.save(variables["configuration_file"])
     Configuration.init(variables["configuration_file"])
     print("Configuration {} deleted.".format(config))

--- a/arlas/cli/configurations.py
+++ b/arlas/cli/configurations.py
@@ -14,12 +14,12 @@ configurations = typer.Typer()
 @configurations.command(help="Set default configuration among existing configurations", name="set", epilog=variables["help_epilog"])
 def set_default_configuration(name: str = typer.Argument(help="Name of the configuration to become default")):
     if not Configuration.settings.arlas.get(name):
-        print("Error: configuration {} not found among {}.".format(name, ",".join(Configuration.settings.arlas.keys())), file=sys.stderr)
+        print(f"Error: configuration {name} not found among {','.join(Configuration.settings.arlas.keys())}.", file=sys.stderr)
         exit(1)
     Configuration.settings.default = name
     Configuration.save(variables["configuration_file"])
     Configuration.init(variables["configuration_file"])
-    print("Default configuration is now {}".format(name))
+    print(f"Default configuration is now {name}")
 
 
 @configurations.command(help="Display the default configuration", name="default", epilog=variables["help_epilog"])
@@ -33,16 +33,17 @@ def default():
 @configurations.command(help="Check the services of a configuration", name="check", epilog=variables["help_epilog"])
 def test_configuration(name: str = typer.Argument(help="Configuration to be checked")):
     if not Configuration.settings.arlas.get(name):
-        print("Error: configuration {} not found among {}.".format(name, ",".join(Configuration.settings.arlas.keys())), file=sys.stderr)
+        print(f"Error: configuration {name} not found among {','.join(Configuration.settings.arlas.keys())}.",
+              file=sys.stderr)
         exit(1)
     print("ARLAS Server: ... ", end="")
-    print(" {}".format(Service.test_arlas_server(name)))
+    print(f" {Service.test_arlas_server(name)}")
     print("ARLAS Persistence: ... ", end="")
-    print(" {}".format(Service.test_arlas_persistence(name)))
+    print(f" {Service.test_arlas_persistence(name)}")
     print("ARLAS IAM: ... ", end="")
-    print(" {}".format(Service.test_arlas_iam(name)))
+    print(f" {Service.test_arlas_iam(name)}")
     print("Elasticsearch: ... ", end="")
-    print(" {}".format(Service.test_es(name)))
+    print(f" {Service.test_es(name)}")
 
 @configurations.command(help="List configurations", name="list", epilog=variables["help_epilog"])
 def list_configurations():
@@ -95,18 +96,21 @@ def create_configuration(
         server=Resource(location=server, headers=dict(map(lambda h: (h.split(":")[0], h.split(":")[1]), headers))),
         allow_delete=allow_delete)
     if persistence:
-        conf.persistence = Resource(location=persistence, headers=dict(map(lambda h: (h.split(":")[0], h.split(":")[1]), persistence_headers)))
+        conf.persistence = Resource(location=persistence,
+                                    headers=dict(map(lambda h: (h.split(":")[0], h.split(":")[1]), persistence_headers)))
 
     if auth_token_url:
         conf.authorization = AuthorizationService(
-            token_url=Resource(login=auth_login, password=auth_password, location=auth_token_url, headers=dict(map(lambda h: (h.split(":")[0], h.split(":")[1]), auth_headers))),
+            token_url=Resource(login=auth_login, password=auth_password, location=auth_token_url,
+                               headers=dict(map(lambda h: (h.split(":")[0], h.split(":")[1]), auth_headers))),
             client_id=auth_client_id,
             client_secret=auth_client_secret,
             grant_type=auth_grant_type,
             arlas_iam=auth_arlas_iam
         )
     if elastic:
-        conf.elastic = Resource(location=elastic, headers=dict(map(lambda h: (h.split(":")[0], h.split(":")[1]), elastic_headers)), login=elastic_login, password=elastic_password)
+        conf.elastic = Resource(location=elastic, login=elastic_login, password=elastic_password,
+                                headers=dict(map(lambda h: (h.split(":")[0], h.split(":")[1]), elastic_headers)))
 
     if len(Configuration.settings.arlas) == 0:
         # Set the first created configuration as default
@@ -116,7 +120,7 @@ def create_configuration(
     Configuration.settings.arlas[name] = conf
     Configuration.save(variables["configuration_file"])
     Configuration.init(variables["configuration_file"])
-    print("Configuration {} created.".format(name))
+    print(f"Configuration {name} created.")
 
 
 @configurations.command(help="Add a configuration for ARLAS Cloud", name="login", epilog=variables["help_epilog"])
@@ -130,21 +134,23 @@ def login(
     elastic_password: str = typer.Option(default=None, help="elasticsearch password")
 ):
     if not re.match(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', auth_login):
-        print("Error: login {} is not a valid email".format(auth_login), file=sys.stderr)
+        print(f"Error: login {auth_login} is not a valid email", file=sys.stderr)
         exit(1)
 
     name = "cloud.arlas.io." + auth_login.split("@")[0]
     if Configuration.settings.arlas.get(name):
         print("Error: a configuration with that name already exists, please remove it first.", file=sys.stderr)
         exit(1)
-    print("Creating configuration for {} ...".format(name))
+    print(f"Creating configuration for {name} ...")
     if not auth_org:
         auth_org = auth_login.split("@")[1]
-        print("Using {} as your organisation name.".format(auth_org))
+        print(f"Using {auth_org} as your organisation name.")
     if not auth_password:
-        auth_password = typer.prompt("Please enter your password for ARLAS Cloud (account {})\n".format(auth_login), hide_input=True, prompt_suffix="Password:")
+        auth_password = typer.prompt(f"Please enter your password for ARLAS Cloud (account {auth_login})\n",
+                                     hide_input=True, prompt_suffix="Password:")
     if not elastic_password:
-        elastic_password = typer.prompt("Thank you, now, please enter your password for elasticsearch (account {})\n".format(elastic_login), hide_input=True, prompt_suffix="Password:")
+        elastic_password = typer.prompt(f"Thank you, now, please enter your password for elasticsearch (account {elastic_login})\n",
+                                        hide_input=True, prompt_suffix="Password:")
 
     create_configuration(
         name=name,
@@ -170,7 +176,7 @@ def login(
     Configuration.settings.default = name
     Configuration.save(variables["configuration_file"])
     Configuration.init(variables["configuration_file"])
-    print("{} is now your default configuration.".format(name))
+    print(f"{name} is now your default configuration.")
 
 
 @configurations.command(help="Delete a configuration", name="delete", epilog=variables["help_epilog"])
@@ -178,7 +184,8 @@ def delete_configuration(
     config: str = typer.Argument(help="Name of the configuration"),
 ):
     if Configuration.settings.arlas.get(config, None) is None:
-        print("Error: arlas configuration {} not found among [{}]".format(config, ", ".join(Configuration.settings.arlas.keys())), file=sys.stderr)
+        print(f"Error: arlas configuration {config} not found among [{','.join(Configuration.settings.arlas.keys())}]",
+              file=sys.stderr)
         exit(1)
     Configuration.settings.arlas.pop(config)
     if Configuration.settings.default == config:
@@ -186,7 +193,7 @@ def delete_configuration(
         print(f"Configuration {config} is no longer the default configuration")
     Configuration.save(variables["configuration_file"])
     Configuration.init(variables["configuration_file"])
-    print("Configuration {} deleted.".format(config))
+    print(f"Configuration {config} deleted.")
 
 
 @configurations.command(help="Describe a configuration", name="describe", epilog=variables["help_epilog"])
@@ -194,6 +201,7 @@ def describe_configuration(
     config: str = typer.Argument(help="Name of the configuration"),
 ):
     if Configuration.settings.arlas.get(config, None) is None:
-        print("Error: arlas configuration {} not found among [{}]".format(config, ", ".join(Configuration.settings.arlas.keys())), file=sys.stderr)
+        print(f"Error: arlas configuration {config} not found among [{','.join(Configuration.settings.arlas.keys())}]",
+              file=sys.stderr)
         exit(1)
     print(yaml.dump(Configuration.settings.arlas[config].model_dump()))

--- a/arlas/cli/configurations.py
+++ b/arlas/cli/configurations.py
@@ -104,6 +104,12 @@ def create_configuration(
         )
     if elastic:
         conf.elastic = Resource(location=elastic, headers=dict(map(lambda h: (h.split(":")[0], h.split(":")[1]), elastic_headers)), login=elastic_login, password=elastic_password)
+
+    if len(Configuration.settings.arlas) == 0:
+        # Set the first created configuration as default
+        Configuration.settings.default = name
+        print(f"Default configuration is now {name}")
+
     Configuration.settings.arlas[name] = conf
     Configuration.save(variables["configuration_file"])
     Configuration.init(variables["configuration_file"])

--- a/arlas/cli/configurations.py
+++ b/arlas/cli/configurations.py
@@ -24,7 +24,10 @@ def set_default_configuration(name: str = typer.Argument(help="Name of the confi
 
 @configurations.command(help="Display the default configuration", name="default", epilog=variables["help_epilog"])
 def default():
-    print("Default configuration is {}".format(Configuration.settings.default))
+    if Configuration.settings.default is None:
+        print("No default configuration")
+    else:
+        print(f"Default configuration is {Configuration.settings.default}")
 
 
 @configurations.command(help="Check the services of a configuration", name="check", epilog=variables["help_epilog"])

--- a/arlas/cli/configurations.py
+++ b/arlas/cli/configurations.py
@@ -45,10 +45,13 @@ def test_configuration(name: str = typer.Argument(help="Configuration to be chec
 def list_configurations():
     confs = []
     for (name, conf) in Configuration.settings.arlas.items():
+        if name == Configuration.settings.default:
+            name += " (*)"
         confs.append([name, conf.server.location])
-    tab = PrettyTable(["name", "url"], sortby="name", align="l")
+    tab = PrettyTable(["name", "ARLAS server url"], sortby="name", align="l")
     tab.add_rows(confs)
     print(tab)
+    print("(*) Default configuration")
 
 
 @configurations.command(help="Add a configuration", name="create", epilog=variables["help_epilog"])

--- a/tests/test_arlas_cli.py
+++ b/tests/test_arlas_cli.py
@@ -214,3 +214,14 @@ def test_persist_groups():
     """Test listing groups for a persisted entry."""
     result = run_cli_command(["persist", "--config", "tests", "groups", "my_zone"])
     assert "group/public" in result.stdout
+
+def test_delete_configuration():
+    """ Test deleting a configuration """
+    result = run_cli_command(["confs", "delete", "tests"])
+    assert result.returncode == 0
+    # Check that 'tests' in no longer listed
+    result = run_cli_command(["confs", "list"])
+    assert "tests" not in result.stdout
+    # Check that 'test' is no longer the default configuration
+    result = run_cli_command(["confs", "default"])
+    assert "tests" not in result.stdout

--- a/tests/test_arlas_cli.py
+++ b/tests/test_arlas_cli.py
@@ -40,7 +40,7 @@ def test_configuration_login():
     assert "cloud.arlas.io.support" in result.stdout
     # Check that the first created conf is set as default
     result = run_cli_command(["confs", "default"])
-    assert "cloud.arlas.io.support" in result.stdout
+    assert "cloud.arlas.io.support" in result.stdout, result.stderr
 
 def test_config_file_exists():
     """Test if the config file exists."""
@@ -57,21 +57,21 @@ def test_create_configuration():
         "--elastic-headers", "Content-Type:application/json",
         "--allow-delete",
     ])
-    assert "tests" in result.stdout
+    assert "tests" in result.stdout, result.stderr
 
 def test_set_default_configuration():
     """Test setting the default configuration."""
     run_cli_command(["confs", "set", "tests"])
     result = run_cli_command(["confs", "default"])
-    assert "tests" in result.stdout
+    assert "tests" in result.stdout, result.stderr
 
 def test_check_configuration():
     """Test checking the configuration."""
     result = run_cli_command(["confs", "check", "tests"])
-    assert "ARLAS Server: ...  ok" in result.stdout
-    assert "ARLAS Persistence: ...  ok" in result.stdout
-    assert "ARLAS IAM: ...  not ok" in result.stdout
-    assert "Elasticsearch: ...  ok" in result.stdout
+    assert "ARLAS Server: ...  ok" in result.stdout, result.stderr
+    assert "ARLAS Persistence: ...  ok" in result.stdout, result.stderr
+    assert "ARLAS IAM: ...  not ok" in result.stdout, result.stderr
+    assert "Elasticsearch: ...  ok" in result.stdout, result.stderr
 
 def test_add_and_retrieve_direct_mapping():
     """Test adding a direct mapping on Elasticsearch."""
@@ -80,7 +80,7 @@ def test_add_and_retrieve_direct_mapping():
         "--mapping", "tests/mapping.json",
     ])
     result = run_cli_command(["indices", "--config", "tests", "list"])
-    assert "direct_mapping_index" in result.stdout
+    assert "direct_mapping_index" in result.stdout, result.stderr
 
 def test_infer_and_add_mapping():
     """Test inferring and adding a mapping on Elasticsearch."""
@@ -95,7 +95,7 @@ def test_infer_and_add_mapping():
     ])
     assert result.returncode == 0
     result = run_cli_command(["indices", "--config", "tests", "list"])
-    assert "courses" in result.stdout
+    assert "courses" in result.stdout, result.stderr
 
 def test_describe_mapping():
     """Test describing the mapping from Elasticsearch."""
@@ -109,16 +109,16 @@ def test_add_data():
         "indices", "--config", "tests", "data", "courses",
         "tests/sample.json", "tests/sample.json",
     ])
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
     time.sleep(2)  # Wait for data to be indexed
     result = run_cli_command(["indices", "--config", "tests", "list"])
-    assert "courses" in result.stdout and "200" in result.stdout
+    assert "courses" in result.stdout and "200" in result.stdout, result.stderr
 
 def test_clone_index():
     """Test cloning an index."""
     run_cli_command(["indices", "--config", "tests", "clone", "courses", "courses2"])
     result = run_cli_command(["indices", "--config", "tests", "list"])
-    assert "courses2" in result.stdout
+    assert "courses2" in result.stdout, result.stderr
     # Clean up
     run_cli_command(["indices", "--config", "tests", "delete", "courses2"], input_data="yes\n")
 
@@ -133,10 +133,10 @@ def test_add_collection():
         "--geometry-path", "track.trail",
         "--date-path", "track.timestamps.center",
     ])
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
     time.sleep(2)
     result = run_cli_command(["collections", "--config", "tests", "list"])
-    assert "courses" in result.stdout
+    assert "courses" in result.stdout, result.stderr
 
 def test_set_field_alias():
     """Test setting a field alias."""
@@ -144,56 +144,56 @@ def test_set_field_alias():
         "collections", "--config", "tests", "set_alias", "courses",
         "track.visibility.proportion", "Proportion",
     ])
-    assert "Proportion" in result.stdout
+    assert "Proportion" in result.stdout, result.stderr
 
 def test_set_collection_name():
     """Test setting a collection name."""
     result = run_cli_command([
         "collections", "--config", "tests", "name", "courses", "thecourses",
     ])
-    assert "thecourses" in result.stdout
+    assert "thecourses" in result.stdout, result.stderr
 
 def test_describe_collection():
     """Test describing a collection."""
     result = run_cli_command(["collections", "--config", "tests", "describe", "courses"])
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
 
 def test_count_collection():
     """Test counting a collection."""
     result = run_cli_command(["collections", "--config", "tests", "count", "courses"])
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
 
 def test_delete_collection():
     """Test deleting a collection."""
     result = run_cli_command(["collections", "--config", "tests", "delete", "courses"], input_data="yes\n")
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
     time.sleep(2)
     result = run_cli_command(["collections", "--config", "tests", "list"])
-    assert "courses" not in result.stdout
+    assert "courses" not in result.stdout, result.stderr
 
 def test_delete_index():
     """Test deleting an index."""
     result = run_cli_command(["indices", "--config", "tests", "delete", "courses"], input_data="yes\n")
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
     time.sleep(2)
     result = run_cli_command(["indices", "--config", "tests", "list"])
-    assert "courses" not in result.stdout
+    assert "courses" not in result.stdout, result.stderr
 
 def test_list_configurations():
     """Test listing configurations."""
     result = run_cli_command(["confs", "list"])
-    assert "tests" in result.stdout
+    assert "tests" in result.stdout, result.stderr
 
 def test_create_and_delete_configuration():
     """Test creating and deleting a configuration."""
     result = run_cli_command(["confs", "create", "toto", "--server", "http://localhost:9999"])
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
     result = run_cli_command(["confs", "list"])
-    assert "toto" in result.stdout
+    assert "toto" in result.stdout, result.stderr
     result = run_cli_command(["confs", "delete", "toto"])
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
     result = run_cli_command(["confs", "list"])
-    assert "toto" not in result.stdout
+    assert "toto" not in result.stdout, result.stderr
 
 def test_persist_add_and_get():
     """Test adding and retrieving a persisted entry."""
@@ -202,18 +202,18 @@ def test_persist_add_and_get():
     ])
     entry_id = result.stdout.strip()
     result = run_cli_command(["persist", "--config", "tests", "zone", "my_zone"])
-    assert "toto" in result.stdout
+    assert "toto" in result.stdout, result.stderr
     result = run_cli_command(["persist", "--config", "tests", "get", entry_id])
     # Test entry content
     with open("README.md", "r") as f:
-        assert f.read() == result.stdout
+        assert f.read() == result.stdout, result.stderr
     result = run_cli_command(["persist", "--config", "tests", "describe", entry_id])
-    assert "toto" in result.stdout
+    assert "toto" in result.stdout, result.stderr
 
 def test_persist_groups():
     """Test listing groups for a persisted entry."""
     result = run_cli_command(["persist", "--config", "tests", "groups", "my_zone"])
-    assert "group/public" in result.stdout
+    assert "group/public" in result.stdout, result.stderr
 
 def test_delete_configuration():
     """ Test deleting a configuration """
@@ -225,7 +225,7 @@ def test_delete_configuration():
     assert result.returncode == 0, result.stderr
     # Check that 'tests' in no longer listed
     result = run_cli_command(["confs", "list"])
-    assert "tests" not in result.stdout
+    assert "tests" not in result.stdout, result.stderr
     # Check that 'test' is no longer the default configuration
     result = run_cli_command(["confs", "default"])
-    assert "tests" not in result.stdout
+    assert "tests" not in result.stdout, result.stderr

--- a/tests/test_arlas_cli.py
+++ b/tests/test_arlas_cli.py
@@ -217,8 +217,12 @@ def test_persist_groups():
 
 def test_delete_configuration():
     """ Test deleting a configuration """
-    result = run_cli_command(["confs", "delete", "tests"])
-    assert result.returncode == 0
+    # Invalid deletion
+    result = run_cli_command(["confs", "delete", "tests"], input_data="no\n")
+    assert result.returncode == 1, result.stdout
+    # Valid deletion
+    result = run_cli_command(["confs", "delete", "tests"], input_data="yes\n")
+    assert result.returncode == 0, result.stderr
     # Check that 'tests' in no longer listed
     result = run_cli_command(["confs", "list"])
     assert "tests" not in result.stdout

--- a/tests/test_arlas_cli.py
+++ b/tests/test_arlas_cli.py
@@ -29,6 +29,23 @@ def run_cli_command(args, input_data=None):
 
 # --- Tests ---
 
+def test_config_file_exists():
+    """Test if the config file exists."""
+    assert config_file_path.exists()
+
+def test_configuration_login():
+    """Test adding a configuration with login."""
+    run_cli_command([
+        "confs", "login", "support@gisaia.com", "support@gisaia.com", "https://some_elastic_search_server",
+        "--auth-password", "toto",
+        "--elastic-password", "titi",
+    ])
+    result = run_cli_command(["confs", "list"])
+    assert "cloud.arlas.io.support" in result.stdout
+    # Check that the first created conf is set as default
+    result = run_cli_command(["confs", "default"])
+    assert "cloud.arlas.io.support" in result.stdout
+
 def test_create_configuration():
     """Test creating a new configuration."""
     result = run_cli_command([
@@ -42,25 +59,11 @@ def test_create_configuration():
     ])
     assert "tests" in result.stdout
 
-def test_configuration_login():
-    """Test adding a configuration with login."""
-    run_cli_command([
-        "confs", "login", "support@gisaia.com", "support@gisaia.com", "https://some_elastic_search_server",
-        "--auth-password", "toto",
-        "--elastic-password", "titi",
-    ])
-    result = run_cli_command(["confs", "list"])
-    assert "cloud.arlas.io.support" in result.stdout
-
-def test_config_file_exists():
-    """Test if the config file exists."""
-    assert config_file_path.exists()
-
 def test_set_default_configuration():
     """Test setting the default configuration."""
     run_cli_command(["confs", "set", "tests"])
     result = run_cli_command(["confs", "default"])
-    assert "Default configuration is tests" in result.stdout
+    assert "tests" in result.stdout
 
 def test_check_configuration():
     """Test checking the configuration."""

--- a/tests/test_arlas_cli.py
+++ b/tests/test_arlas_cli.py
@@ -29,10 +29,6 @@ def run_cli_command(args, input_data=None):
 
 # --- Tests ---
 
-def test_config_file_exists():
-    """Test if the config file exists."""
-    assert config_file_path.exists()
-
 def test_configuration_login():
     """Test adding a configuration with login."""
     run_cli_command([
@@ -45,6 +41,10 @@ def test_configuration_login():
     # Check that the first created conf is set as default
     result = run_cli_command(["confs", "default"])
     assert "cloud.arlas.io.support" in result.stdout
+
+def test_config_file_exists():
+    """Test if the config file exists."""
+    assert config_file_path.exists()
 
 def test_create_configuration():
     """Test creating a new configuration."""


### PR DESCRIPTION
Main changes:
- Display default configuration witsh a `(*)` in `confs list` (fix https://github.com/gisaia/arlas_cli/issues/76)
- When ther is no configuration, the first created configuration is now set as default conf  (fix https://github.com/gisaia/arlas_cli/issues/66)
- The "local" configuration is no longer created at initialisation

Side changes:
- If the default configuration is deleted, the "default confs" is unset
- Improve log messages related to confs operations