### PR TITLE
Add sonarcube properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+# Exclude path from SonarQube scan. Path is relative to the sonar-project.properties file.
+sonar.exclusions=docs/site/**


### PR DESCRIPTION
Changes:
- Add sonar cube properties file to avoid inspect `doc/site` folder (duplication)

Note:
- This is to make the CI pass as there is a duplication between `docs/docs` (md) and `docs/site` (html)